### PR TITLE
Link Join button to Discourse Community, fix broken links

### DIFF
--- a/community.md
+++ b/community.md
@@ -14,9 +14,9 @@
 		href="https://bnd.discourse.group">discussion group on Discourse</a>. We encourage general discussion about
 	all topics related to building with Bndtools or bnd, including the
 	use of the <a
-		href="http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html">Maven
+		href="https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html">Maven
 		Bundle Plugin</a> (which uses bnd internally) or the <a
-		href="http://www.aqute.biz/Bnd/Components">bnd annotations for
+		href="https://bnd.bndtools.org/chapters/200-components.html">bnd annotations for
 		Declarative Services</a>.
 </p>
 <p>

--- a/community.md
+++ b/community.md
@@ -23,7 +23,7 @@
 	<a class="button small"
 		href="http://groups.google.com/group/bndtools-users">View
 		Archive &raquo;</a> <a class="button small"
-		href="http://groups.google.com/group/bndtools-users/subscribe">Join
+		href="https://bnd.discourse.group">Join
 		&raquo;</a>
 </p>
 </li>


### PR DESCRIPTION
Since the Google group is read-only it only makes sense to join the Discourse community.
