### PR TITLE
Add word "forum" to the link to the discourse

### DIFF
--- a/_includes/head.htm
+++ b/_includes/head.htm
@@ -1,6 +1,7 @@
     <head>
         <meta charset="utf-8">
-        <title>Bndtools</title>
+        <title>{% if page.title %}{{ page.title }} - {% endif %}Bndtools</title>
+        {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=2.0">
         <link rel="stylesheet" href="/css/style.css" />
         <link rel="shortcut icon" href="/images/favicon.ico">

--- a/community.md
+++ b/community.md
@@ -1,10 +1,8 @@
 ---
+title: Get Involved
+description: Discuss and and report issues with the bndtools community.
 ---
 
-
-<div class="hero">
-	<h1>Get Involved</h1>
-</div>
 
 <ul class="row">
 <li class="large-6 medium-6 small-6 columns">

--- a/community.md
+++ b/community.md
@@ -11,7 +11,7 @@
 <h1>Discuss</h1>
 <p>
 	Bndtools and bnd use a combined <a
-		href="https://bnd.discourse.group">discussion group on Discourse</a>. We encourage general discussion about
+		href="https://bnd.discourse.group">forum / discussion group on Discourse</a>. We encourage general discussion about
 	all topics related to building with Bndtools or bnd, including the
 	use of the <a
 		href="https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html">Maven


### PR DESCRIPTION
add the word "forum" to improve findability of https://bnd.discourse.group/  e.g. when searching for the terms "bndtools forum". 