### PR TITLE
Added /tutorial.html to top + side nav

### DIFF
--- a/_includes/nav.htm
+++ b/_includes/nav.htm
@@ -11,7 +11,7 @@
   <section class="top-bar-section">
     <ul class="left">
       <li><a href="/installation.html">Install</a></li>
-      <li><a href="/workspace/osgi-starter.html">Tutorial</a></li>
+      <li><a href="/tutorial.html">Tutorial</a></li>
       <li><a href="/workspace.html">Videos</a></li>
     </ul>
     <ul class="right">

--- a/_includes/sidebar.htm
+++ b/_includes/sidebar.htm
@@ -5,6 +5,7 @@
   <li class="divider" />
   <li class="heading">Documentation</li>
   <li><a href="/installation.html">Installation</a></li>
+  <li><a href="/tutorial.html">Tutorial</a></li>
   <li><a href="/workspace.html">Video Tour</a></li>
   <li><a href="/concepts.html">Concepts</a></li>
   <li><a href="/workspace/osgi-starter.html">OSGi Starter</a></li>

--- a/index.md
+++ b/index.md
@@ -2,8 +2,8 @@
 ---
 
 <div class="hero panel radius">
-    <h1><img src="images/swirl-128.png" alt="Logo" class="logo"> Bndtools</h1>
-    <p>The easy, powerful, and productive way to develop with OSGi. Based on <a href="https://bnd.bndtools.org">bnd</a> and <a href="www.eclipse.org">Eclipse</a>.</p>
+    <h1><img src="images/swirl-128.png" alt="Logo" class="logo">Bndtools</h1>
+    <p>The easy, powerful, and productive way to develop with OSGi. Based on <a href="https://bnd.bndtools.org">bnd</a> and <a href="https://www.eclipse.org/ide/">Eclipse IDE</a>.</p>
     <p><a class="button small" href="installation.html">Install now &raquo;</a></p>
 </div>
 


### PR DESCRIPTION
/tutorial.html was another hidden gem which was not linked in the main nav but hidden on the (previously hidden) Developer Guide. Now it is spot on in the front. I put it to top and side nav because currently both kinda duplicate the important points. We can change that in the future, but for now I kept this pattern. Also fixed a dead link to eclipse.