### PR TITLE
Improve mobile website display (stack sidebar to bottom on small screens)

### DIFF
--- a/_includes/footer.htm
+++ b/_includes/footer.htm
@@ -20,4 +20,11 @@
     </div>
 </div>
 
+<script src="/js/jquery.js"></script>
+<script src="/js/foundation.min.js"></script>
 
+<script>
+    $( document ).ready(function() {
+        $(document).foundation();
+    });
+</script>

--- a/_includes/head.htm
+++ b/_includes/head.htm
@@ -2,8 +2,9 @@
         <meta charset="utf-8">
         <title>{% if page.title %}{{ page.title }} - {% endif %}Bndtools</title>
         {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
-        <meta name="viewport" content="width=device-width, initial-scale=2.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="/css/style.css" />
         <link rel="shortcut icon" href="/images/favicon.ico">
         <script src="/js/modernizr.js"></script>
+        
     </head>

--- a/_includes/nav.htm
+++ b/_includes/nav.htm
@@ -2,7 +2,7 @@
   <ul class="title-area">
     <li class="name">
       <h1>
-        <a href="index.html"
+        <a href="/index.html"
           ><img src="/images/logo-topbar.png" alt="Bndtools"
         /></a>
       </h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,17 +6,38 @@
     {% include nav.htm %}
 
     <div class="row main-container">
-      
+
       <!-- Main Content -->
       <div class="large-9 medium-8 medium-push-4 large-push-3 columns">
-        <div class="hero">
-          <h1>{{ page.title }}</h1>
+        <div class="off-canvas-wrap move" data-offcanvas>
+          <div class="inner-wrap">
+        
+            <a role="button" href="#" class="show-for-small-only left-off-canvas-toggle menu-icon" style="background-color: darkgray;" ><span></span></a>
+        
+            <!-- Off Canvas Menu -->
+            <aside id="#" class="left-off-canvas-menu" aria-hidden="true">
+                <!-- whatever you want goes here -->
+                {% include sidebar.htm %}
+            </aside>
+        
+            <!-- main content goes here -->
+            <div class="hero">
+              <h1>{{ page.title }}</h1>
+            </div>
+            {{content}}
+        
+          <!-- close the off-canvas menu -->
+          <a class="exit-off-canvas"></a>
+        
+          </div>
         </div>
-        {{content}}
+
+        
+       
       </div>
       
       <!-- Sidebar -->
-      <div class="large-3 medium-4 medium-pull-8 large-pull-9 columns">
+      <div class="hide-for-small-only large-3 medium-4 medium-pull-8 large-pull-9 columns">
         <div class="sidebar">
           <nav>
             {% include sidebar.htm %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,17 @@
     {% include nav.htm %}
 
     <div class="row main-container">
+      
+      <!-- Main Content -->
+      <div class="large-9 medium-8 medium-push-4 large-push-3 columns">
+        <div class="hero">
+          <h1>{{ page.title }}</h1>
+        </div>
+        {{content}}
+      </div>
+      
       <!-- Sidebar -->
-      <div class="large-3 medium-4 small-4 columns">
+      <div class="large-3 medium-4 medium-pull-8 large-pull-9 columns">
         <div class="sidebar">
           <nav>
             {% include sidebar.htm %}
@@ -15,13 +24,9 @@
         </div>
       </div>
 
-      <!-- Main Content -->
-      <div class="large-9 medium-8 small-8 columns">
-        <div class="hero">
-          <h1>{{ page.title }}</h1>
-        </div>
-        {{content}}
-      </div>
+      
+
+
     </div>
 
     {% include footer.htm %}

--- a/css/style.scss
+++ b/css/style.scss
@@ -72,3 +72,7 @@ signature {
     font-size: 1.3rem;
   }
 }
+
+.left-off-canvas-menu{
+  background: none !important;  
+}


### PR DESCRIPTION
Improves experience when viewing on mobile phones.
I used https://get.foundation/sites/docs-v5/components/grid.html (scroll down to **Source Ordering**) and Off-Canvas for the sidebar https://get.foundation/sites/docs-v5/components/offcanvas.html

**Before this PR**

sidebar steals width of main content. 

<img width="557" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/9d5e24e2-5b4b-4bf2-9908-7bf725123a56">

**After the fix**

Large:

<img width="1727" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/5a093a70-04f1-4216-88df-fc755ad07cab">

Medium:

<img width="948" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/14b0ca19-0a19-4c86-9232-4e01020a2400">


Small ( sidebar on the left is collapsed and a hamburger menu is shown which can show the side bar again)

<img width="463" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/1f7eeda3-20a8-446e-92e2-66f3189536cf">


<img width="497" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/fa4c790b-a2d7-4d97-ba8b-d098a249cb3b">
