### PR TITLE
Improve texts

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -44,12 +44,15 @@ nav:
     links:
       - name: About OSGi
         url: "/book/210-doc.html"
+        urlprefix: "/doc/"
       - name: Services
         url: "/book/400-services.html"
+        urlprefix: "/services/"
       - name: Tutorials
         url: "/book/150-tutorials.html"  
       - name: App Notes
         url: "/book/680-appnotes.html"
+        urlprefix: "/appnotes/"
       - name: Examples
         url: "/book/180-examples.html"
   - title: Development

--- a/_includes/sidebar.htm
+++ b/_includes/sidebar.htm
@@ -12,6 +12,8 @@
           {% assign isActive = true %}
         {% elsif page.url contains link.url and link.url != "/" %}
           {% assign isActive = true %}
+        {% elsif page.url contains link.urlprefix %}
+          {% assign isActive = true %}  
         {% endif %}
         <li class="{% if isActive %}active{% endif %}">
           <a href="{{ link.url }}" {% if link.external %}class="external-left"{% endif %}>

--- a/_services/org.osgi.service.coordinator.md
+++ b/_services/org.osgi.service.coordinator.md
@@ -18,6 +18,71 @@ To implement this, the service checks if there is a current _Coordination_ assoc
 
 The Coordinator service provides a way for collaborating OSGi bundles to coordinate their activities and manage the lifecycle of a larger task or operation. By associating a _Coordination_ with the current thread, any service or component involved in the task can access information about the overall state and progress of the operation. This allows for optimizations like caching intermediate results or batching updates, as shown in the example.
 
+## Example Code for Using the OSGi Coordinator Service
+
+Here's an example of how you can use the OSGi Coordinator service in your code:
+
+```java
+import org.osgi.service.coordinator.Coordination;
+import org.osgi.service.coordinator.Coordinator;
+import org.osgi.service.coordinator.Participant;
+
+public class UserInfoService {
+    private Coordinator coordinator;
+
+    public void setUserInfo(String userId, String info) {
+        // Check if there is a current Coordination
+        Coordination coordination = coordinator.peek();
+        if (coordination != null) {
+            // Wait for the Coordination to complete
+            coordination.join();
+        }
+
+        // Process the user info update
+        updateUserInfo(userId, info);
+    }
+
+    private void updateUserInfo(String userId, String info) {
+        // Logic to update the user information
+        System.out.println("Updating user " + userId + " with info: " + info);
+    }
+
+    public void activate() {
+        // Get the Coordinator service
+        coordinator = getCoordinatorService();
+
+        // Register a Participant to be notified when the Coordination completes
+        coordinator.begin("UserInfoUpdate", new Participant() {
+            @Override
+            public void ended(Coordination coordination) {
+                // Perform any cleanup or post-processing here
+                System.out.println("UserInfoUpdate Coordination ended");
+            }
+
+            @Override
+            public void failed(Coordination coordination) {
+                // Handle any errors or failures here
+                System.out.println("UserInfoUpdate Coordination failed");
+            }
+        });
+    }
+
+    private Coordinator getCoordinatorService() {
+        // Obtain the Coordinator service from the OSGi service registry
+        // (implementation details omitted for brevity)
+    }
+}
+```
+
+In this example, the `UserInfoService` uses the Coordinator service to coordinate the updates to user information. When the `setUserInfo` method is called, the service first checks if there is a current Coordination associated with the thread. If so, it waits for the Coordination to complete before processing the data.
+
+The `activate` method of the service obtains the Coordinator service and begins a new Coordination named "UserInfoUpdate". It also registers a `Participant` that will be notified when the Coordination ends or fails.
+
+By using the Coordinator service, the `UserInfoService` can batch the user info updates and perform them more efficiently, improving the overall performance of the application. The Participant also allows the service to perform any necessary cleanup or post-processing when the Coordination completes.
+
+This is just a simple example, but the Coordinator service can be used in more complex scenarios where multiple OSGi bundles need to coordinate their activities and manage the lifecycle of a larger task or operation.
+
+
 The key points are:
 
 ### Coordination of Collaborating Bundles
@@ -32,3 +97,8 @@ The key points are:
 - Services can delay processing until all requests are received
 - Allows batching updates or caching intermediate results
 - Improves overall performance of the application
+
+
+## Links
+
+- <https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.coordinator.html>

--- a/_services/org.osgi.service.coordinator.md
+++ b/_services/org.osgi.service.coordinator.md
@@ -11,4 +11,24 @@ The OSGi programming model is based on the collaboration of standard and custom 
 
 To know when a task involving multiple collaborators has ended is the primary purpose of the Coordinator service specification. The Coordinator service provides a rendezvous for a _requestor_ to create a _Coordination_ that is then associated with the current thread. When the request finished, the Coordination is _terminated_. Through the Coordinator service anybody being called on the thread can find the _current Coordination_, similar to how transactions are governed.
 
-For example let's assume a service is called that sets some information for the current user. Since the API is designed to take element by element, it is generally called a number of times in a web request. Going to the database for each request can be expensive. The service can therefore delay the processing until all requests have been received. To implement this, the service checks 
+## Example Use Case
+
+For example let's assume a service is called that sets some information for the current user. Since the API is designed to take element by element, it is generally called a number of times in a web request. Going to the database for each request can be expensive. The service can therefore delay the processing until all requests have been received. 
+To implement this, the service checks if there is a current _Coordination_ associated with the thread, and if so, it waits for the _Coordination_ to complete before processing the data. This allows the service to batch the updates and perform them more efficiently, improving the overall performance of the application.
+
+The Coordinator service provides a way for collaborating OSGi bundles to coordinate their activities and manage the lifecycle of a larger task or operation. By associating a _Coordination_ with the current thread, any service or component involved in the task can access information about the overall state and progress of the operation. This allows for optimizations like caching intermediate results or batching updates, as shown in the example.
+
+The key points are:
+
+### Coordination of Collaborating Bundles
+- OSGi model has no central authority, so coordination is needed
+- Coordinator service provides a rendezvous point for managing task lifecycle
+
+### Accessing the Current Coordination
+- _Coordination_ is associated with the current thread
+- Any service can access the current _Coordination_ to participate in the task
+
+### Optimizing Performance
+- Services can delay processing until all requests are received
+- Allows batching updates or caching intermediate results
+- Improves overall performance of the application

--- a/_services/org.osgi.service.event.md
+++ b/_services/org.osgi.service.event.md
@@ -19,25 +19,29 @@ The Event Admin service captures this commonality.
 
 The following code shows a component that handles an event on the topic: `some/topic`. 
 
-	import org.osgi.service.event.Event;
-	import org.osgi.service.event.EventHandler;
-	import org.osgi.service.event.EventConstants;
-	
-	@Component( property= EventConstants.EVENT_TOPIC + "=some/topic")
-	public class SomeListenerImpl implements EventHandler {
-	
-	    @Override
-	    public void handleEvent(Event event) {
-	        System.out.println("Got event " + event);
-	    }
+```java
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.EventConstants;
+
+@Component( property= EventConstants.EVENT_TOPIC + "=some/topic")
+public class SomeListenerImpl implements EventHandler {
+
+	@Override
+	public void handleEvent(Event event) {
+		System.out.println("Got event " + event);
 	}
+}
+```
 
 ## Example Generator
 
 The following code shows a component that sends an event every second using the [scheduler][scheduler]. 
 
-    @Component(property=CronJob.CRON+"=* * * * * ?")
-    public class EventSource {
+```java
+@Component(property=CronJob.CRON+"=* * * * * ?")
+public class EventSource {
+
 	EventAdmin	eventAdmin;
 	
 	public void run(Object object) {
@@ -49,19 +53,24 @@ The following code shows a component that sends an event every second using the 
 	void setEventAdmin( EventAdmin eventAdmin) {
 		this.eventAdmin = eventAdmin;
 	}
-    }
+}
+```
 
 
 
 
 Nearly all the bundles in an OSGi framework must deal with events, either as an event publisher or as an event handler. So far, the preferred mechanism to disperse those events have been the service interface mechanism.
 
-Dispatching events for a design related to X, usually involves a service of type XListener. However, this model does not scale well for fine grained events that must be dispatched to many different handlers. Additionally, the dynamic nature of the OSGi environment introduces several complexi- ties because both event publishers and event handlers can appear and disappear at any time.
+Dispatching events for a design related to _X_, usually involves a service of type _XListener_. However, this model does not scale well for fine grained events that must be dispatched to many different handlers. Additionally, the dynamic nature of the OSGi environment introduces several complexities because both event _publishers_ and event _handlers_ can appear and disappear at any time.
+
+## Summary
 
 The Event Admin service provides an inter-bundle communication mechanism. It is based on a event publish and subscribe model, popular in many message based systems.
 This specification defines the details for the participants in this event model.
 
+## Links
 
+- <https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.event.html>
 
 
 [scheduler]: /services/osgi.enroute.scheduler.api.html

--- a/_services/org.osgi.service.http.md
+++ b/_services/org.osgi.service.http.md
@@ -7,18 +7,75 @@ summary:  An HTTP server framework
 
 ![Http Service Collaboration Diagram](/img/services/org.osgi.service.http.overview.png)
 
-An OSGi framework normally provides users with access to services on the Internet and other net- works. This access allows users to remotely retrieve information from, and send control to, services in an OSGi framework using a standard web browser.
-Bundle developers typically need to develop communication and user interface solutions for stan- dard technologies such as HTTP, HTML, XML, and servlets.
+An OSGi framework normally provides users with access to services on the Internet and other networks. This access allows users to remotely retrieve information from, and send control to, services in an OSGi framework using a standard web browser.
+Bundle developers typically need to develop communication and user interface solutions for standard technologies such as HTTP, HTML, XML, and servlets.
 
 The Http Service supports two standard techniques for this purpose:
 
-* Registering servlets – A servlet is a Java object which implements the Java Servlet API. Registering a servlet in the Framework gives it control over some part of the Http Service URI name-space.
-* Registering resources – Registering a resource allows HTML files, image files, and other static re- sources to be made visible in the Http Service URI name-space by the requesting bundle.
+* Registering servlets – A servlet is a Java object which implements the Java Servlet API. Registering a servlet in the Framework gives it control over some part of the Http Service URI namespace.
+* Registering resources – Registering a resource allows HTML files, image files, and other static resources to be made visible in the Http Service URI name-space by the requesting bundle.
 Implementations of the Http Service can be based on:
   * [HTTP 1.0 Specification RFC-1945][1] 
   * [HTTP 1.1 Specification RFC-2616][2] 
 
-Alternatively, implementations of this service can support other protocols if these protocols can conform to the semantics of the javax.servlet API. This additional support is necessary because the Http Service is closely related to [3] Java Servlet Technology. Http Service implementations must sup- port at least version 2.1 of the Java Servlet API.
+Alternatively, implementations of this service can support other protocols if these protocols can conform to the semantics of the javax.servlet API. This additional support is necessary because the Http Service is closely related to [3] Java Servlet Technology. Http Service implementations must support at least version 2.1 of the Java Servlet API.
+
+## OSGi HTTP Whiteboard Pattern
+
+The OSGi HTTP Whiteboard pattern provides a declarative way to register servlets and resources with the Http Service, using annotations instead of programmatic registration.
+
+### Registering Servlets
+
+To register a servlet using the HTTP Whiteboard pattern, you can use the `@javax.servlet.annotation.WebServlet` annotation on your servlet class. This annotation allows you to specify the URL pattern that the servlet should handle.
+
+```java
+import org.osgi.service.component.annotations.Component;
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component(service = Servlet.class, property = {
+    "osgi.http.whiteboard.servlet.pattern=/myservlet"
+})
+public class MyServlet implements Servlet {
+    @Override
+    public void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.getWriter().write("Hello from MyServlet!");
+    }
+}
+```
+
+In this example, the `@Component` annotation declares that the `MyServlet` class is a service of type `Servlet`. The `osgi.http.whiteboard.servlet.pattern` property specifies the URL pattern that the servlet should handle, in this case, `/myservlet`.
+
+### Registering Resources
+
+To register a resource using the HTTP Whiteboard pattern, you can use the `@org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN` annotation on your resource provider class.
+
+```java
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+@Component(property = {
+    HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN + "=/resources/*",
+    HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX + "=/web"
+})
+public class MyResourceProvider {
+    // No implementation needed, the annotations are enough
+}
+```
+
+In this example, the `@Component` annotation declares a resource provider service. The `HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN` property specifies the URL pattern that the resources should be served from, in this case, `/resources/*`. The `HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX` property specifies the directory in the bundle's resources that should be used to serve the static files, in this case, `/web`.
+
+## Summary
+
+The OSGi HTTP Whiteboard pattern provides a declarative way to register servlets and resources with the Http Service, using annotations instead of programmatic registration. This approach simplifies the process of exposing HTTP-based services and resources in an OSGi framework, making it easier for bundle developers to create web-based applications on top of the OSGi platform.
+
+
+## Links
+
+- <https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.http.html>
+- <https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.http.whiteboard.html>
 
 [1]: HTTP 1.0 Specification RFC-1945, http://www.ietf.org/rfc/rfc1945.txt, May 1996
 [2]: HTTP 1.1 Specification RFC-2616, http://www.ietf.org/rfc/rfc2616.txt, June 1999

--- a/_services/org.osgi.service.http.whiteboard.md
+++ b/_services/org.osgi.service.http.whiteboard.md
@@ -4,3 +4,58 @@ layout: prev-next-collection
 version: 1.0
 summary:  Allows Servlets & Filters to be registered as OSGi services 
 ---
+
+## OSGi HTTP Whiteboard Pattern
+
+The OSGi HTTP Whiteboard pattern provides a declarative way to register servlets and resources with the Http Service, using annotations instead of programmatic registration.
+
+### Registering Servlets
+
+To register a servlet using the HTTP Whiteboard pattern, you can use the `@javax.servlet.annotation.WebServlet` annotation on your servlet class. This annotation allows you to specify the URL pattern that the servlet should handle.
+
+```java
+import org.osgi.service.component.annotations.Component;
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component(service = Servlet.class, property = {
+    "osgi.http.whiteboard.servlet.pattern=/myservlet"
+})
+public class MyServlet implements Servlet {
+    @Override
+    public void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.getWriter().write("Hello from MyServlet!");
+    }
+}
+```
+
+In this example, the `@Component` annotation declares that the `MyServlet` class is a service of type `Servlet`. The `osgi.http.whiteboard.servlet.pattern` property specifies the URL pattern that the servlet should handle, in this case, `/myservlet`.
+
+### Registering Resources
+
+To register a resource using the HTTP Whiteboard pattern, you can use the `@org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN` annotation on your resource provider class.
+
+```java
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+@Component(property = {
+    HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN + "=/resources/*",
+    HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX + "=/web"
+})
+public class MyResourceProvider {
+    // No implementation needed, the annotations are enough
+}
+```
+
+In this example, the `@Component` annotation declares a resource provider service. The `HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN` property specifies the URL pattern that the resources should be served from, in this case, `/resources/*`. The `HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX` property specifies the directory in the bundle's resources that should be used to serve the static files, in this case, `/web`.
+
+## Summary
+
+The OSGi HTTP Whiteboard pattern provides a declarative way to register servlets and resources with the Http Service, using annotations instead of programmatic registration. This approach simplifies the process of exposing HTTP-based services and resources in an OSGi framework, making it easier for bundle developers to create web-based applications on top of the OSGi platform.
+
+## Links
+
+- <https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.http.whiteboard.html>

--- a/_services/osgi.enroute.easse.md
+++ b/_services/osgi.enroute.easse.md
@@ -50,7 +50,7 @@ A full working example can be found at [OSGi enRoute Examples][easseexample].
  
 ## Description
 
-This service uses [OSGi Event Admin][ea] to forward events from the OSGi Framework towards the front-end using Javascript's [Server Sent Events][sse] (also see [EventSource][EventSource]). Since OSGi eventes are properties, this is quite straightforward.
+This service uses [OSGi Event Admin][ea] to forward events from the OSGi Framework towards the front-end using Javascript's [Server Sent Events][sse] (also see [EventSource][es]). Since OSGi eventes are properties, this is quite straightforward.
 
 The service can be used by annotating the application main class  `RequireEventAdminServerSentEventsWebResource`, this will include the `enEasse` angular module (see the WebResource Namespace for more information).
 
@@ -75,4 +75,4 @@ Since the connection consumes resources it is important to close the connection 
 [ea]: /services/org.osgi.service.event.html
 [easseexample]: https://github.com/osgi/osgi.enroute.examples/tree/master/osgi.enroute.examples.easse.application
 [sse]: http://www.w3schools.com/html/html5_serversentevents.asp
-[EventSource]: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
+[es]: https://developer.mozilla.org/en-US/docs/Web/API/EventSource

--- a/_services/osgi.enroute.easse.md
+++ b/_services/osgi.enroute.easse.md
@@ -17,36 +17,40 @@ This service can also be used to eavesdrop on the OSGi events.
 
 In the Java code you can use the `RequireEventAdminServerSentEventsWebResource` to include the library Javascript code in your index.html page.
 
-	@RequireEventAdminServerSentEventsWebResource
-	@RequireAngularWebResource(resource={"angular.js"}, priority=1000)
-	@RequireWebServerExtender
-	@Component(name="osgi.enroute.example.eventadminserversentevents")
-	public class EventadminserversenteventsApplication{ }
+```java
+@RequireEventAdminServerSentEventsWebResource
+@RequireAngularWebResource(resource={"angular.js"}, priority=1000)
+@RequireWebServerExtender
+@Component(name="osgi.enroute.example.eventadminserversentevents")
+public class EventadminserversenteventsApplication{ }
+```
 
 The skeleton of the Javascript looks as follows:
 
-	var events = [];
+```javascript
+var events = [];
 
-	var MODULE = angular.module('osgi.enroute.example.easse',
-			[ "enEasse"]);
+var MODULE = angular.module('osgi.enroute.example.easse',
+		[ "enEasse"]);
 
-	MODULE.run( function($rootScope, en$easse) {
-		$rootScope.events = events;
-		
-		en$easse.handle("some/topic/*", function(e) {
-			$rootScope.$applyAsync(function() {
-				events.push(e);
-			});
-		}, function(error) {
-			console.log("EASSE error: " + msg);
-		} );
-	});
+MODULE.run( function($rootScope, en$easse) {
+	$rootScope.events = events;
+	
+	en$easse.handle("some/topic/*", function(e) {
+		$rootScope.$applyAsync(function() {
+			events.push(e);
+		});
+	}, function(error) {
+		console.log("EASSE error: " + msg);
+	} );
+});
+```
 
 A full working example can be found at [OSGi enRoute Examples][easseexample].
  
 ## Description
 
-This service uses [OSGi Event Admin][ea] to forward events from the OSGi Framework towards the front-end using Javascript's [Server Sent Events][sse]. Since OSGi eventes are properties, this is quite straightforward.
+This service uses [OSGi Event Admin][ea] to forward events from the OSGi Framework towards the front-end using Javascript's [Server Sent Events][sse] (also see [EventSource][EventSource]). Since OSGi eventes are properties, this is quite straightforward.
 
 The service can be used by annotating the application main class  `RequireEventAdminServerSentEventsWebResource`, this will include the `enEasse` angular module (see the WebResource Namespace for more information).
 
@@ -55,16 +59,20 @@ The `enEasse` module will register an `en$easse` service. This service has the f
 * `handle(topic, messageCallback, errorCallback, logCallback, scope)` – This will create a watcher on the Event Admin stream connected to this application. 
 	* `topic` – The topic can contain the normal wildcard as specified in the Event Admin specification (e.g. `some/topic/*`). 
 	* `messageCallback(properties)` – The message callback should be placed in an asynchronous body for Angular:
+
+```javascript		
+$rootScope.$applyAsync(function() {
+		events.push(properties);
+});
+```
 		
-		$rootScope.$applyAsync(function() {
-				events.push(properties);
-		});
-	* `errorCallback(error)` – Indicates any errors
-	* `logCallback(message)` – Progress information
-	* `scope` – If provided, will be used for the life cycle. If the scope is terminated, the handle will also be closed
+* `errorCallback(error)` – Indicates any errors
+* `logCallback(message)` – Progress information
+* `scope` – If provided, will be used for the life cycle. If the scope is terminated, the handle will also be closed
 
 Since the connection consumes resources it is important to close the connection when no longer needed. If a scope is provided then the connection is closed when that scope is destroyed. Otherwise, the handle's return object should be closed by calling `close()` on it.
  
 [ea]: /services/org.osgi.service.event.html
 [easseexample]: https://github.com/osgi/osgi.enroute.examples/tree/master/osgi.enroute.examples.easse.application
 [sse]: http://www.w3schools.com/html/html5_serversentevents.asp
+[EventSource]: https://developer.mozilla.org/en-US/docs/Web/API/EventSource


### PR DESCRIPTION
WIP services


- org.osgi.service.coordinator: Establish a coordinator service for managing thread-based requests with callback capabilities.
- org.osgi.service.event: Set up a simple publish and subscribe system for handling generic events.
- org.osgi.service.http: Build an HTTP server framework.
- org.osgi.service.http.whiteboard: Enable the registration of Servlets and Filters as OSGi services.
- osgi.enroute.easse: Implement a service to dispatch OSGi Event Admin events to the front-end using Server Sent Events.

Also improved the "active" link behavior in the sidebar slightly using a very simple mechanism.

`sidebar.yml`
<img width="408" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/5822c5e4-20e3-4f4a-9400-7c91d9bceda4">

<img width="1291" alt="image" src="https://github.com/bndtools/bndtools.github.io/assets/188422/454ba4f5-a7bc-48b8-82ab-02a0fe8c8691">

Although I am on a subpage the sidebar link is still shown as active. 
Should work for our purposes. 