### PR TITLE
add Pagefind Search for bndtools website

### DIFF
--- a/.github/scripts/docs.sh
+++ b/.github/scripts/docs.sh
@@ -4,3 +4,6 @@ gem --version
 bundle --version
 
 bundle exec jekyll build
+
+# create search index under _site/pagefind
+./pagefind --verbose --site _site

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -36,6 +36,18 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
+    
+    # Download and install the Pagefind binary
+    # see releases: https://github.com/CloudCannon/pagefind/releases
+    - name: Install Pagefind for Search
+      run: |
+        curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz \
+          -o pagefind.tar.gz
+        tar xzf pagefind.tar.gz
+        chmod +x pagefind
+    
     - name: Build
       run: |
         ./.github/scripts/docs.sh
+
+    

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /vendor/
 /bundler/
 .jekyll-metadata
+pagefind*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ This should install jekyll and start a local webserver at:
 
 Start editing markdown `.md` files. Jekyll will auto-detect changes and reload the website. Some changes require a restart (e.g. changes to `_config.yml`)
 
+## Local development with Pagefind search
+
+We use https://pagefind.app/ for our search field full text search. 
+But it is currently not automatically working when using `./run.sh` above, because it works on the 
+actual build-output on the `_site` folder (which contains the actual `.html` pages). 
+
+To test the search locally based on the `_site` folder content, run:
+
+
+`./run-pagefind-linux.sh`
+
+or
+
+`run-pagefind-macos.sh`
+
+depending on which operating system you are using. 
+
+The result should look like:
+
+`Serving "_site" at http://localhost:1414`
+
+
+The script will download and execute the pagefind executable binary after the build.
+Then it will start a small server where you test the result. 
+Note, that this is different than the `./run.sh` and does not support real-time editing of the content.
+
+Feel free to adjust / extend the start-scripts if you have a different architecture 
+or to use a different `pagefind` version. 
+
+### pagefind for production build via github actions
+
+See the files `.github/workflows/cibuild.yml` and `.github/scripts/docs.sh` for how 
+building the site and executing `pagefind` is done in the final build on github.
+
 ### CSS Styling for Code Highlighter
 
 - jekyll uses `rouge` code highlighter

--- a/_config.yml
+++ b/_config.yml
@@ -64,4 +64,5 @@ exclude:
   - '.project'
   - 'run.sh'
   - '/vendor'
+  - '/pagefind'
 

--- a/_layouts/baselayout.html
+++ b/_layouts/baselayout.html
@@ -7,6 +7,15 @@
 
     <div class="row main-container">
 
+      <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+      <script src="/pagefind/pagefind-ui.js"></script>
+      <div id="search"></div>
+      <script>
+          window.addEventListener('DOMContentLoaded', (event) => {
+              new PagefindUI({ element: "#search", showSubResults: true });
+          });
+      </script>
+
       <!-- Main Content -->
       <div class="large-9 medium-8 medium-push-4 large-push-3 columns">
         <div class="off-canvas-wrap move" data-offcanvas>
@@ -21,8 +30,9 @@
             </aside>
             
             <!-- main content goes here -->
+            <main data-pagefind-body>
             {{content}}
-            
+            </main>
           <!-- close the off-canvas menu -->
           <a class="exit-off-canvas"></a>
         

--- a/run-pagefind-linux.sh
+++ b/run-pagefind-linux.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ev
+
+# Build into _site folder
+export BUNDLE_GEMFILE=$PWD/Gemfile
+bundle install --jobs=3 --retry=3 --path=vendor
+bundle exec jekyll clean
+bundle exec jekyll build
+
+# Run and serve the _site folder with search working
+# install Linux x86_64
+curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz -o pagefind.tar.gz
+tar xzf pagefind.tar.gz
+chmod +x pagefind
+./pagefind --site _site --serve

--- a/run-pagefind-macos.sh
+++ b/run-pagefind-macos.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ev
+
+# Build into _site folder
+export BUNDLE_GEMFILE=$PWD/Gemfile
+bundle install --jobs=3 --retry=3 --path=vendor
+bundle exec jekyll clean
+bundle exec jekyll build
+
+# Run and serve the _site folder with search working
+# install for MacOS aarch64
+curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-aarch64-apple-darwin.tar.gz -o pagefind.tar.gz
+tar xzf pagefind.tar.gz
+chmod +x pagefind
+./pagefind --site _site --serve


### PR DESCRIPTION
see https://pagefind.app/docs/installation/
and https://pagefind.app/docs/

The build output looks like this:

```
Run ./.github/scripts/docs.sh
ruby 2.7.[8](https://github.com/bndtools/bndtools.github.io/actions/runs/13346832283/job/37278307569?pr=237#step:7:9)p225 (2023-03-30 revision 1f4d455848) [x86_64-linux]
3.1.6
Bundler version 2.1.4
Configuration file: /home/runner/work/bndtools.github.io/bndtools.github.io/_config.yml
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
            Source: /home/runner/work/bndtools.github.io/bndtools.github.io
       Destination: /home/runner/work/bndtools.github.io/bndtools.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 3.871 seconds.
 Auto-regeneration: disabled. Use --watch to enable.

Running Pagefind v1.3.0
Running in verbose mode
Running from: "/home/runner/work/bndtools.github.io/bndtools.github.io"
Source:       "_site"
Output:       "_site/pagefind"

[Walking source directory]
Found 151 files matching **/*.{html}

[Parsing files]
Found a data-pagefind-body element on the site.
↳ Ignoring pages without this tag.

[Reading languages]
Discovered 1 language: en
  * en: 150 pages

[Building search indexes]
Language en: 
  Indexed 150 pages
  Indexed 6[9](https://github.com/bndtools/bndtools.github.io/actions/runs/13346832283/job/37278307569?pr=237#step:7:10)33 words
  Indexed 0 filters
  Indexed 0 sorts

Total: 
  Indexed 1 language
  Indexed 150 pages
  Indexed 6933 words
  Indexed 0 filters
  Indexed 0 sorts

Finished in 1.006 seconds
```