### PR TITLE
Revert "build(deps): Bump ruby/setup-ruby from 1.202.0 to 1.255.0"

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Ruby
-      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
+      uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
       with:
         ruby-version: 2.7
         bundler-cache: true


### PR DESCRIPTION
Reverts bndtools/bndtools.github.io#248

Because build fails with:

```
nokogiri-1.16.5-x86_64-linux requires ruby version < 3.4.dev, >= 3.0, which is
incompatible with the current version, ruby 2.7.8p225
Error: The process '/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle' failed with exit code 
```