### PR TITLE
Add Bndtools 7.2.0 release post and update docs

### DIFF
--- a/_posts/2025-12-26-bndtools-7.2.0.md
+++ b/_posts/2025-12-26-bndtools-7.2.0.md
@@ -1,0 +1,13 @@
+---
+layout: prev-next-collection
+title: Bndtools 7.2.0 released
+description: We are happy to announce a new release.
+comments: true
+author: Christoph Rüger
+---
+
+Bnd / Bndtools version 7.2.0 has been released.
+Check the [Github Release](https://github.com/bndtools/bnd/releases/tag/7.2.0) to find out what's new in this release. 
+
+You can download and install it [here](https://bndtools.org/installation.html). This contains various options for users and also developers, who want to contribute to bnd / bndtools.
+

--- a/installation.md
+++ b/installation.md
@@ -1,8 +1,8 @@
 ---
-title: Installation & Getting Started with Bndtools 7.1.0
+title: Installation & Getting Started with Bndtools
 ---
 
-There are now three ways to Install Bndtools 7.1.0+
+There are now three ways to Install Bndtools
 
 ## Eclipse Marketplace Install
 
@@ -24,7 +24,7 @@ Note that Eclipse must be previously installed prior to using this installation 
 
 | Type                       |URL                                                    |alt. URL|
 |----------------------------|-------------------------------------------------------|--|
-| Latest stable release      | `https://bndtools.org/bndtools.p2.repo/7.1.0/`       | via [jfrog](https://bndtools.jfrog.io/bndtools/update-latest)  |
+| Latest stable release      | `https://bndtools.org/bndtools.p2.repo/7.2.0/`       | via [jfrog](https://bndtools.jfrog.io/bndtools/update-latest)  |
 | Latest release candidate   | `https://bndtools.jfrog.io/bndtools/update-rc`          ||
 | Latest build snapshot      | `https://bndtools.jfrog.io/bndtools/update-snapshot`    ||
 
@@ -35,7 +35,7 @@ Note that Eclipse must be previously installed prior to using this installation 
 
 If you want to start fresh with a clean Eclipse installation, this option is for you.
 
-The pre-configured setups automatically **install and configure Eclipse**, along with **all required components** for Bndtools — such as Git support, recommended Eclipse plugins, and **Bndtools 7.1.0** itself.
+The pre-configured setups automatically **install and configure Eclipse**, along with **all required components** for Bndtools — such as Git support, recommended Eclipse plugins, and **Bndtools** itself.
 
 These setups **do not require an existing Eclipse installation**, making them an easy way for new users to get a fully working Bndtools environment in just a few steps.
 
@@ -67,7 +67,7 @@ For more complete information on the changes in the Bndtools release, see <https
 
 ## Known Issues
 
-* Bndtools is built to run on Eclipse 2022-09 or later. So Bndtools 7.1.0 may not run on older versions of Eclipse.
+* Bndtools is built to run on Eclipse 2023-12 or later. So Bndtools may not run on older versions of Eclipse.
 
 * This release is based on Java 17. This tends to be not noticed for development but there are a number of runtime bundles in the distribution that now also have become Java 17 code. This could generate the error during a bndrun launch or with bnd/OSGi testing when the Execution Environment is set to < 17. The easy fix is to set this to 17. If this is impossible, the previous launchers than run on 1.8 can then be used (if they are available in the repositories). Add
 ```


### PR DESCRIPTION
Added a new blog post announcing the release of Bndtools 7.2.0. Updated installation instructions and references in installation.md to reflect the new version, including repository URLs and Eclipse compatibility requirements.

Release: https://github.com/bndtools/bnd/releases/tag/7.2.0